### PR TITLE
fix directory on find_packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     extras_require=extras_require,
     packages=(['electrum_ltc',]
               + [('electrum_ltc.'+pkg) for pkg in
-                 find_packages('electrum_ltc', exclude=["tests"])]),
+                 find_packages('electrum', exclude=["tests"])]),
     package_dir={
         'electrum_ltc': 'electrum'
     },


### PR DESCRIPTION
find_packages takes a source code directory. It is therefore `electrum` instead of `electrum_ltc`.
package_dir replacements only take effect afterwards.